### PR TITLE
[Backport]  Newsletter Label is broking on chinese Language like 订阅

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Magento is thankful for any contribution that can improve our code base, documen
 
 <h2>Reporting security issues</h2>
 
-To report security vulnerabilities in Magento software or web sites, please e-mail <a href="mailto:security@magento.com">security@magento.com</a>. Please do not report security issues using GitHub. Be sure to encrypt your e-mail with our <a href="https://info2.magento.com/rs/magentoenterprise/images/security_at_magento.asc">encryption key</a> if it includes sensitive information. Learn more about reporting security issues <a href="https://magento.com/security/reporting-magento-security-issue">here</a>.
+To report security vulnerabilities in Magento software or web sites, please create a Bugcrowd researcher account <a href="https://bugcrowd.com/magento">there</a> to submit and follow-up your issue. Learn more about reporting security issues <a href="https://magento.com/security/reporting-magento-security-issue">here</a>.
 
 Stay up-to-date on the latest vulnerabilities and patches for Magento by signing up for <a href="https://magento.com/security/sign-up">Security Alert Notifications</a>.
 

--- a/app/code/Magento/Braintree/etc/adminhtml/system.xml
+++ b/app/code/Magento/Braintree/etc/adminhtml/system.xml
@@ -44,7 +44,7 @@
                         <comment>http://docs.magento.com/m2/ce/user_guide/payment/braintree.html</comment>
                         <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Hint</frontend_model>
                     </group>
-                    <group id="braintree_required" translate="label" showInDefault="1" showInWebsite="1" sortOrder="5">
+                    <group id="braintree_required" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="5">
                         <comment><![CDATA[<a href="https://www.braintreegateway.com/login" target="_blank">Click here to login to your existing Braintree account</a>. Or to setup a new account and accept payments on your website, <a href="https://apply.braintreegateway.com/signup/us" target="_blank">click here to signup for a Braintree account</a>.<br><br>Powered by <a href="https://www.braintreepayments.com/features/hosted-fields" target="_blank">Braintree v.zero with Hosted Fields</a> latest technology. Hosted Fields are small, transparent iframes that replace the sensitive credit card inputs in your checkout flow - helping you meet the latest data security requirements while ensuring your customization doesn't suffer. <a href="https://www.braintreepayments.com/features/hosted-fields" target="_blank">Find out more</a>.]]></comment>
                         <label>Basic Braintree Settings</label>
                         <attribute type="expanded">1</attribute>
@@ -78,7 +78,7 @@
                             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                         </field>
                     </group>
-                    <group id="braintree_advanced" translate="label" showInDefault="1" showInWebsite="1" sortOrder="20">
+                    <group id="braintree_advanced" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="20">
                         <label>Advanced Braintree Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="braintree_cc_vault_title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -126,7 +126,7 @@
                             <config_path>payment/braintree/sort_order</config_path>
                         </field>
                     </group>
-                    <group id="braintree_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="30">
+                    <group id="braintree_country_specific" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="30">
                         <label>Country Specific Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -147,7 +147,7 @@
                             <config_path>payment/braintree/countrycreditcard</config_path>
                         </field>
                     </group>
-                    <group id="braintree_paypal" translate="label" showInDefault="1" showInWebsite="1" sortOrder="40">
+                    <group id="braintree_paypal" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="40">
                         <label>PayPal through Braintree</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -216,7 +216,7 @@
                             <config_path>payment/braintree_paypal/skip_order_review</config_path>
                         </field>
                     </group>
-                    <group id="braintree_3dsecure" translate="label" showInDefault="1" showInWebsite="1" sortOrder="41">
+                    <group id="braintree_3dsecure" translate="label" showInDefault="1" showInWebsite="1" showInStore="0" sortOrder="41">
                         <label>3D Secure Verification Settings</label>
                         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
                         <field id="verify_3dsecure" translate="label" type="select" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -240,7 +240,7 @@
                             <config_path>payment/braintree/verify_specific_countries</config_path>
                         </field>
                     </group>
-                    <group id="braintree_dynamic_descriptor" translate="label" showInDefault="1" showInWebsite="1" sortOrder="50">
+                    <group id="braintree_dynamic_descriptor" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="50">
                         <label>Dynamic Descriptors</label>
                         <comment><![CDATA[Dynamic descriptors are sent on a per-transaction basis and define what will appear on your customers credit card statements for a specific purchase.
                             The clearer the description of your product, the less likely customers will issue chargebacks due to confusion or non-recognition.

--- a/app/code/Magento/Braintree/view/frontend/templates/paypal/button.phtml
+++ b/app/code/Magento/Braintree/view/frontend/templates/paypal/button.phtml
@@ -30,7 +30,7 @@ $config = [
        class="action-braintree-paypal-logo" disabled>
         <img class="braintree-paypal-button-hidden"
              src="https://checkout.paypal.com/pwpp/2.17.6/images/pay-with-paypal.png"
-             alt="<?= $block->escapeHtml(__('Pay with PayPal')) ?>"
-             title="<?= $block->escapeHtml(__('Pay with PayPal')) ?>"/>
+             alt="<?php echo $block->escapeHtml(__('Pay with PayPal')); ?>"
+             title="<?php echo $block->escapeHtml(__('Pay with PayPal')); ?>"/>
     </button>
 </div>

--- a/app/code/Magento/Braintree/view/frontend/templates/paypal/button.phtml
+++ b/app/code/Magento/Braintree/view/frontend/templates/paypal/button.phtml
@@ -30,6 +30,7 @@ $config = [
        class="action-braintree-paypal-logo" disabled>
         <img class="braintree-paypal-button-hidden"
              src="https://checkout.paypal.com/pwpp/2.17.6/images/pay-with-paypal.png"
-             alt="Pay with PayPal"/>
+             alt="<?= $block->escapeHtml(__('Pay with PayPal')) ?>"
+             title="<?= $block->escapeHtml(__('Pay with PayPal')) ?>"/>
     </button>
 </div>

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Checkbox.php
@@ -15,7 +15,7 @@ class Checkbox extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Op
     /**
      * @var string
      */
-    protected $_template = 'product/composite/fieldset/options/type/checkbox.phtml';
+    protected $_template = 'Magento_Bundle::product/composite/fieldset/options/type/checkbox.phtml';
 
     /**
      * @param  string $elementId

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Multi.php
@@ -15,7 +15,7 @@ class Multi extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Optio
     /**
      * @var string
      */
-    protected $_template = 'product/composite/fieldset/options/type/multi.phtml';
+    protected $_template = 'Magento_Bundle::product/composite/fieldset/options/type/multi.phtml';
 
     /**
      * @param  string $elementId

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Radio.php
@@ -15,7 +15,7 @@ class Radio extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Optio
     /**
      * @var string
      */
-    protected $_template = 'product/composite/fieldset/options/type/radio.phtml';
+    protected $_template = 'Magento_Bundle::product/composite/fieldset/options/type/radio.phtml';
 
     /**
      * @param  string $elementId

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Composite/Fieldset/Options/Type/Select.php
@@ -15,7 +15,7 @@ class Select extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Opti
     /**
      * @var string
      */
-    protected $_template = 'product/composite/fieldset/options/type/select.phtml';
+    protected $_template = 'Magento_Bundle::product/composite/fieldset/options/type/select.phtml';
 
     /**
      * @param  string $elementId

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle.php
@@ -20,7 +20,7 @@ class Bundle extends \Magento\Backend\Block\Widget implements \Magento\Backend\B
     /**
      * @var string
      */
-    protected $_template = 'product/edit/bundle.phtml';
+    protected $_template = 'Magento_Bundle::product/edit/bundle.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -26,7 +26,7 @@ class Option extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'product/edit/bundle/option.phtml';
+    protected $_template = 'Magento_Bundle::product/edit/bundle/option.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Search.php
@@ -15,7 +15,7 @@ class Search extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'product/edit/bundle/option/search.phtml';
+    protected $_template = 'Magento_Bundle::product/edit/bundle/option/search.phtml';
 
     /**
      * @return void

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option/Selection.php
@@ -15,7 +15,7 @@ class Selection extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'product/edit/bundle/option/selection.phtml';
+    protected $_template = 'Magento_Bundle::product/edit/bundle/option/selection.phtml';
 
     /**
      * Catalog data

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Checkbox.php
@@ -15,5 +15,5 @@ class Checkbox extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Op
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/view/type/bundle/option/checkbox.phtml';
+    protected $_template = 'Magento_Bundle::catalog/product/view/type/bundle/option/checkbox.phtml';
 }

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -15,5 +15,22 @@ class Multi extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Optio
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/view/type/bundle/option/multi.phtml';
+    protected $_template = 'Magento_Bundle::catalog/product/view/type/bundle/option/multi.phtml';
+
+    /**
+     * @inheritdoc
+     * @since 100.2.0
+     */
+    protected function assignSelection(\Magento\Bundle\Model\Option $option, $selectionId)
+    {
+        if (is_array($selectionId)) {
+            foreach ($selectionId as $id) {
+                if ($id && $option->getSelectionById($id)) {
+                    $this->_selectedOptions[] = $id;
+                }
+            }
+        } else {
+            parent::assignSelection($option, $selectionId);
+        }
+    }
 }

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Multi.php
@@ -16,21 +16,4 @@ class Multi extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Optio
      * @var string
      */
     protected $_template = 'Magento_Bundle::catalog/product/view/type/bundle/option/multi.phtml';
-
-    /**
-     * @inheritdoc
-     * @since 100.2.0
-     */
-    protected function assignSelection(\Magento\Bundle\Model\Option $option, $selectionId)
-    {
-        if (is_array($selectionId)) {
-            foreach ($selectionId as $id) {
-                if ($id && $option->getSelectionById($id)) {
-                    $this->_selectedOptions[] = $id;
-                }
-            }
-        } else {
-            parent::assignSelection($option, $selectionId);
-        }
-    }
 }

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Radio.php
@@ -15,5 +15,5 @@ class Radio extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Optio
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/view/type/bundle/option/radio.phtml';
+    protected $_template = 'Magento_Bundle::catalog/product/view/type/bundle/option/radio.phtml';
 }

--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle/Option/Select.php
@@ -15,5 +15,5 @@ class Select extends \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Opti
     /**
      * @var string
      */
-    protected $_template = 'catalog/product/view/type/bundle/option/select.phtml';
+    protected $_template = 'Magento_Bundle::catalog/product/view/type/bundle/option/select.phtml';
 }

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Text.php
@@ -81,7 +81,7 @@ class Text extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
      */
     public function prepareForCart()
     {
-        if ($this->getIsValid() && strlen($this->getUserValue()) > 0) {
+        if ($this->getIsValid() && ($this->getUserValue() !== '')) {
             return $this->getUserValue();
         } else {
             return null;

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -8,6 +8,7 @@
 
 namespace Magento\CatalogImportExport\Model\Import;
 
+use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface as ValidatorInterface;
 use Magento\Framework\Model\ResourceModel\Db\TransactionManagerInterface;
@@ -2549,8 +2550,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $useConfigFields = array();
         foreach ($rowData as $key => $value) {
-            $useConfigName = $key === 'enable_qty_increments'
-                ? 'use_config_enable_qty_inc'
+            $useConfigName = $key === StockItemInterface::ENABLE_QTY_INCREMENTS
+                ? StockItemInterface::USE_CONFIG_ENABLE_QTY_INC
                 : self::INVENTORY_USE_CONFIG_PREFIX . $key;
 
             if (isset($this->defaultStockData[$key])

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2549,7 +2549,10 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $useConfigFields = array();
         foreach ($rowData as $key => $value) {
-            $useConfigName = self::INVENTORY_USE_CONFIG_PREFIX . $key;
+            $useConfigName = $key === 'enable_qty_increments'
+                ? 'use_config_enable_qty_inc'
+                : self::INVENTORY_USE_CONFIG_PREFIX . $key;
+
             if (isset($this->defaultStockData[$key])
                 && isset($this->defaultStockData[$useConfigName])
                 && !empty($value)

--- a/app/code/Magento/Checkout/i18n/en_US.csv
+++ b/app/code/Magento/Checkout/i18n/en_US.csv
@@ -180,3 +180,4 @@ Payment,Payment
 "Not yet calculated","Not yet calculated"
 "We received your order!","We received your order!"
 "Thank you for your purchase!","Thank you for your purchase!"
+"Password", "Password"

--- a/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
@@ -39,7 +39,7 @@
                 </label>
                 <div class="control">
                     <input class="input-text"
-                           placeholder="password"
+                           placeholder="Password"
                            type="password"
                            name="password"
                            id="customer-password"

--- a/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/form/element/email.html
@@ -39,7 +39,7 @@
                 </label>
                 <div class="control">
                     <input class="input-text"
-                           placeholder="optional"
+                           placeholder="password"
                            type="password"
                            name="password"
                            id="customer-password"

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
@@ -13,10 +13,8 @@
  */
 ?>
 
-<?php $block->getCurrencySymbolsData();?>
-
-<form id="currency-symbols-form" action="<?php /* @escapeNotVerified */ echo $block->getFormActionUrl() ?>" method="post">
-    <input name="form_key" type="hidden" value="<?php /* @escapeNotVerified */ echo $block->getFormKey() ?>" />
+<form id="currency-symbols-form" action="<?= /* @escapeNotVerified */ $block->getFormActionUrl() ?>" method="post">
+    <input name="form_key" type="hidden" value="<?= /* @escapeNotVerified */ $block->getFormKey() ?>" />
     <fieldset class="admin__fieldset">
         <?php foreach ($block->getCurrencySymbolsData() as $code => $data): ?>
         <div class="admin__field _required">

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
@@ -42,7 +42,7 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
      * @param SampleInterface $sample
      * @return string
      */
-    public function getSampleUrl(SampleInterface $sample)
+    public function getSampleUrl($sample)
     {
         return $this->getUrl('downloadable/download/sample', ['sample_id' => $sample->getId()]);
     }

--- a/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Catalog/Product/Samples.php
@@ -8,7 +8,8 @@
 
 namespace Magento\Downloadable\Block\Catalog\Product;
 
-use Magento\Downloadable\Model\ResourceModel\Sample;
+use Magento\Downloadable\Model\ResourceModel\Sample\Collection as SampleCollection;
+use Magento\Downloadable\Api\Data\SampleInterface;
 
 /**
  * Downloadable Product Samples part block
@@ -30,7 +31,7 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
     /**
      * Get downloadable product samples
      *
-     * @return array
+     * @return SampleCollection
      */
     public function getSamples()
     {
@@ -38,10 +39,10 @@ class Samples extends \Magento\Catalog\Block\Product\AbstractProduct
     }
 
     /**
-     * @param Sample $sample
+     * @param SampleInterface $sample
      * @return string
      */
-    public function getSampleUrl($sample)
+    public function getSampleUrl(SampleInterface $sample)
     {
         return $this->getUrl('downloadable/download/sample', ['sample_id' => $sample->getId()]);
     }

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Problem.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Problem.php
@@ -17,7 +17,7 @@ class Problem extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'problem/list.phtml';
+    protected $_template = 'Magento_Newsletter::problem/list.phtml';
 
     /**
      * @var \Magento\Newsletter\Model\ResourceModel\Problem\Collection

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Edit.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Queue/Edit.php
@@ -16,7 +16,7 @@ class Edit extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'queue/edit.phtml';
+    protected $_template = 'Magento_Newsletter::queue/edit.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Subscriber.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Subscriber.php
@@ -25,7 +25,7 @@ class Subscriber extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'subscriber/list.phtml';
+    protected $_template = 'Magento_Newsletter::subscriber/list.phtml';
 
     /**
      * @var \Magento\Newsletter\Model\ResourceModel\Queue\CollectionFactory

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template.php
@@ -16,7 +16,7 @@ class Template extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'template/list.phtml';
+    protected $_template = 'Magento_Newsletter::template/list.phtml';
 
     /**
      * @return $this

--- a/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Form.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Form.php
@@ -13,5 +13,5 @@ class Form extends \Magento\Backend\Block\Template
     /**
      * @var string
      */
-    protected $_template = 'billing/agreement/view/form.phtml';
+    protected $_template = 'Magento_Paypal::billing/agreement/view/form.phtml';
 }

--- a/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View/Tab/Info.php
@@ -15,7 +15,7 @@ class Info extends \Magento\Backend\Block\Template implements \Magento\Backend\B
     /**
      * @var string
      */
-    protected $_template = 'billing/agreement/view/tab/info.phtml';
+    protected $_template = 'Magento_Paypal::billing/agreement/view/tab/info.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Advanced.php
@@ -16,5 +16,5 @@ class Advanced extends \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink
      *
      * @var string
      */
-    protected $_template = 'system/config/payflowlink/advanced.phtml';
+    protected $_template = 'Magento_Paypal::system/config/payflowlink/advanced.phtml';
 }

--- a/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/System/Config/Payflowlink/Info.php
@@ -16,7 +16,7 @@ class Info extends \Magento\Config\Block\System\Config\Form\Field
      *
      * @var string
      */
-    protected $_template = 'system/config/payflowlink/info.phtml';
+    protected $_template = 'Magento_Paypal::system/config/payflowlink/info.phtml';
 
     /**
      * Render fieldset html

--- a/app/code/Magento/Paypal/Block/Hosted/Pro/Form.php
+++ b/app/code/Magento/Paypal/Block/Hosted/Pro/Form.php
@@ -15,5 +15,5 @@ class Form extends \Magento\Payment\Block\Form
     /**
      * @var string
      */
-    protected $_template = 'hss/info.phtml';
+    protected $_template = 'Magento_Paypal::hss/info.phtml';
 }

--- a/app/code/Magento/Paypal/Block/Iframe.php
+++ b/app/code/Magento/Paypal/Block/Iframe.php
@@ -41,7 +41,7 @@ class Iframe extends \Magento\Payment\Block\Form
     /**
      * @var string
      */
-    protected $_template = 'hss/js.phtml';
+    protected $_template = 'Magento_Paypal::hss/js.phtml';
 
     /**
      * @var \Magento\Sales\Model\OrderFactory

--- a/app/code/Magento/Paypal/Block/Payflow/Advanced/Form.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Advanced/Form.php
@@ -15,7 +15,7 @@ class Form extends \Magento\Paypal\Block\Payflow\Link\Form
     /**
      * @var string
      */
-    protected $_template = 'payflowadvanced/info.phtml';
+    protected $_template = 'Magento_Paypal::payflowadvanced/info.phtml';
 
     /**
      * Get frame action URL

--- a/app/code/Magento/Paypal/Block/Payflow/Link/Form.php
+++ b/app/code/Magento/Paypal/Block/Payflow/Link/Form.php
@@ -15,7 +15,7 @@ class Form extends \Magento\Payment\Block\Form
     /**
      * @var string
      */
-    protected $_template = 'payflowlink/info.phtml';
+    protected $_template = 'Magento_Paypal::payflowlink/info.phtml';
 
     /**
      * Get frame action URL

--- a/app/code/Magento/Reports/Block/Adminhtml/Product/Viewed.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Product/Viewed.php
@@ -15,7 +15,7 @@ class Viewed extends \Magento\Backend\Block\Widget\Grid\Container
     /**
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * @return void

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers.php
@@ -17,7 +17,7 @@ class Bestsellers extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Coupons.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Coupons.php
@@ -17,7 +17,7 @@ class Coupons extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Invoiced.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Invoiced.php
@@ -17,7 +17,7 @@ class Invoiced extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Refunded.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Refunded.php
@@ -17,7 +17,7 @@ class Refunded extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Sales.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Sales.php
@@ -17,7 +17,7 @@ class Sales extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Shipping.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Shipping.php
@@ -17,7 +17,7 @@ class Shipping extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Tax.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Tax.php
@@ -17,7 +17,7 @@ class Tax extends \Magento\Backend\Block\Widget\Grid\Container
      *
      * @var string
      */
-    protected $_template = 'report/grid/container.phtml';
+    protected $_template = 'Magento_Reports::report/grid/container.phtml';
 
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Reports/Block/Adminhtml/Wishlist.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Wishlist.php
@@ -18,7 +18,7 @@ class Wishlist extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'report/wishlist.phtml';
+    protected $_template = 'Magento_Reports::report/wishlist.phtml';
 
     /**
      * Reports wishlist collection factory

--- a/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
@@ -17,7 +17,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     /**
      * @var string
      */
-    protected $_template = 'rating/form.phtml';
+    protected $_template = 'Magento_Review::rating/form.phtml';
 
     /**
      * Session

--- a/app/code/Magento/Review/Block/Adminhtml/Rss/Grid/Link.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rss/Grid/Link.php
@@ -14,7 +14,7 @@ class Link extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rss/grid/link.phtml';
+    protected $_template = 'Magento_Review::rss/grid/link.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\UrlBuilderInterface

--- a/app/code/Magento/Review/Block/Customer/Recent.php
+++ b/app/code/Magento/Review/Block/Customer/Recent.php
@@ -17,7 +17,7 @@ class Recent extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'customer/list.phtml';
+    protected $_template = 'Magento_Review::customer/list.phtml';
 
     /**
      * Product reviews collection

--- a/app/code/Magento/Review/Block/Customer/View.php
+++ b/app/code/Magento/Review/Block/Customer/View.php
@@ -21,7 +21,7 @@ class View extends \Magento\Catalog\Block\Product\AbstractProduct
      *
      * @var string
      */
-    protected $_template = 'customer/view.phtml';
+    protected $_template = 'Magento_Review::customer/view.phtml';
 
     /**
      * Catalog product model

--- a/app/code/Magento/Review/Block/Rating/Entity/Detailed.php
+++ b/app/code/Magento/Review/Block/Rating/Entity/Detailed.php
@@ -15,7 +15,7 @@ class Detailed extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'detailed.phtml';
+    protected $_template = 'Magento_Review::detailed.phtml';
 
     /**
      * @var \Magento\Review\Model\RatingFactory

--- a/app/code/Magento/Review/Block/View.php
+++ b/app/code/Magento/Review/Block/View.php
@@ -17,7 +17,7 @@ class View extends \Magento\Catalog\Block\Product\AbstractProduct
      *
      * @var string
      */
-    protected $_template = 'view.phtml';
+    protected $_template = 'Magento_Review::view.phtml';
 
     /**
      * Rating option model

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Address/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Address/Form.php
@@ -19,7 +19,7 @@ class Form extends \Magento\Sales\Block\Adminhtml\Order\Create\Form\Address
      *
      * @var string
      */
-    protected $_template = 'order/address/form.phtml';
+    protected $_template = 'Magento_Sales::order/address/form.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Grandtotal.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Grandtotal.php
@@ -20,7 +20,7 @@ class Grandtotal extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defa
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/grandtotal.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/grandtotal.phtml';
 
     /**
      * Tax config

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Shipping.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Shipping.php
@@ -20,7 +20,7 @@ class Shipping extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defaul
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/shipping.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/shipping.phtml';
 
     /**
      * Tax config

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Subtotal.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Subtotal.php
@@ -20,7 +20,7 @@ class Subtotal extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defaul
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/subtotal.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/subtotal.phtml';
 
     /**
      * Tax config

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Tax.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Tax.php
@@ -18,5 +18,5 @@ class Tax extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\DefaultTota
      *
      * @var string
      */
-    protected $_template = 'order/create/totals/tax.phtml';
+    protected $_template = 'Magento_Sales::order/create/totals/tax.phtml';
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Details.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Details.php
@@ -14,5 +14,5 @@ class Details extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/details.phtml';
+    protected $_template = 'Magento_Sales::order/details.phtml';
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Form.php
@@ -17,5 +17,5 @@ class Form extends \Magento\Backend\Block\Template
      *
      * @var string
      */
-    protected $_template = 'order/view/form.phtml';
+    protected $_template = 'Magento_Sales::order/view/form.phtml';
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/History.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/History.php
@@ -17,7 +17,7 @@ class History extends \Magento\Backend\Block\Template implements \Magento\Backen
      *
      * @var string
      */
-    protected $_template = 'order/view/tab/history.phtml';
+    protected $_template = 'Magento_Sales::order/view/tab/history.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Adminhtml/Rss/Order/Grid/Link.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Rss/Order/Grid/Link.php
@@ -14,7 +14,7 @@ class Link extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rss/order/grid/link.phtml';
+    protected $_template = 'Magento_Sales::rss/order/grid/link.phtml';
 
     /**
      * @var \Magento\Framework\App\Rss\UrlBuilderInterface

--- a/app/code/Magento/Sales/Block/Order/Info/Buttons.php
+++ b/app/code/Magento/Sales/Block/Order/Info/Buttons.php
@@ -16,7 +16,7 @@ class Buttons extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/info/buttons.phtml';
+    protected $_template = 'Magento_Sales::order/info/buttons.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Order/Info/Buttons/Rss.php
+++ b/app/code/Magento/Sales/Block/Order/Info/Buttons/Rss.php
@@ -13,7 +13,7 @@ class Rss extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/info/buttons/rss.phtml';
+    protected $_template = 'Magento_Sales::order/info/buttons/rss.phtml';
 
     /**
      * @var \Magento\Sales\Model\OrderFactory

--- a/app/code/Magento/Sales/Block/Order/Invoice.php
+++ b/app/code/Magento/Sales/Block/Order/Invoice.php
@@ -15,7 +15,7 @@ class Invoice extends \Magento\Sales\Block\Order\Invoice\Items
     /**
      * @var string
      */
-    protected $_template = 'order/invoice.phtml';
+    protected $_template = 'Magento_Sales::order/invoice.phtml';
 
     /**
      * @var \Magento\Framework\App\Http\Context

--- a/app/code/Magento/Sales/Block/Order/View.php
+++ b/app/code/Magento/Sales/Block/Order/View.php
@@ -15,7 +15,7 @@ class View extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'order/view.phtml';
+    protected $_template = 'Magento_Sales::order/view.phtml';
 
     /**
      * Core registry

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -993,8 +993,24 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param string $comment
      * @param bool|string $status
      * @return OrderStatusHistoryInterface
+     * @deprecated
+     * @see addCommentToStatusHistory
      */
-    public function addStatusHistoryComment($comment, $status = false, $isVisibleOnFront = false)
+    public function addStatusHistoryComment($comment, $status = false)
+    {
+        return $this->addCommentToStatusHistory($comment, $status, false);
+    }
+    
+    /**
+     * Add a comment to order status history
+     * Different or default status may be specified
+     *
+     * @param string $comment
+     * @param bool|string $status
+     * @param bool $isVisibleOnFront
+     * @return OrderStatusHistoryInterface
+     */
+    public function addCommentToStatusHistory($comment, $status = false, $isVisibleOnFront = false)
     {
         if (false === $status) {
             $status = $this->getStatus();

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -994,7 +994,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param bool|string $status
      * @return OrderStatusHistoryInterface
      */
-    public function addStatusHistoryComment($comment, $status = false)
+    public function addStatusHistoryComment($comment, $status = false, $isVisibleOnFront = false)
     {
         if (false === $status) {
             $status = $this->getStatus();
@@ -1009,6 +1009,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             $comment
         )->setEntityName(
             $this->entityType
+        )->setIsVisibleOnFront(
+            $isVisibleOnFront
         );
         $this->addStatusHistory($history);
         return $history;

--- a/app/code/Magento/Search/Api/SynonymGroupRepositoryInterface.php
+++ b/app/code/Magento/Search/Api/SynonymGroupRepositoryInterface.php
@@ -28,7 +28,7 @@ interface SynonymGroupRepositoryInterface
     public function delete(\Magento\Search\Api\Data\SynonymGroupInterface $synonymGroup);
 
     /**
-     * Return a paritcular synonym group interface instance based on passed in synonym group id
+     * Return a particular synonym group interface instance based on passed in synonym group id
      *
      * @param int $synonymGroupId
      * @return \Magento\Search\Api\Data\SynonymGroupInterface

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
@@ -31,7 +31,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     /**
      * @var string
      */
-    protected $_template = 'rate/form.phtml';
+    protected $_template = 'Magento_Tax::rate/form.phtml';
 
     /**
      * Tax data

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Title.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Title.php
@@ -23,7 +23,7 @@ class Title extends \Magento\Framework\View\Element\Template
     /**
      * @var string
      */
-    protected $_template = 'rate/title.phtml';
+    protected $_template = 'Magento_Tax::rate/title.phtml';
 
     /**
      * @var \Magento\Store\Model\StoreFactory

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Add.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Add.php
@@ -18,7 +18,7 @@ class Add extends \Magento\Backend\Block\Template implements \Magento\Backend\Bl
     /**
      * @var string
      */
-    protected $_template = 'toolbar/rate/add.phtml';
+    protected $_template = 'Magento_Tax::toolbar/rate/add.phtml';
 
     /**
      * @var \Magento\Backend\Block\Widget\Button\ButtonList

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Save.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Toolbar/Save.php
@@ -16,7 +16,7 @@ class Save extends \Magento\Backend\Block\Template implements \Magento\Backend\B
     /**
      * @var string
      */
-    protected $_template = 'toolbar/rate/save.phtml';
+    protected $_template = 'Magento_Tax::toolbar/rate/save.phtml';
 
     /**
      * @var \Magento\Backend\Block\Widget\Button\ButtonList

--- a/app/code/Magento/Tax/Block/Checkout/Grandtotal.php
+++ b/app/code/Magento/Tax/Block/Checkout/Grandtotal.php
@@ -15,7 +15,7 @@ class Grandtotal extends \Magento\Checkout\Block\Total\DefaultTotal
      *
      * @var string
      */
-    protected $_template = 'checkout/grandtotal.phtml';
+    protected $_template = 'Magento_Tax::checkout/grandtotal.phtml';
 
     /**
      * @var \Magento\Tax\Model\Config

--- a/app/code/Magento/Tax/Block/Checkout/Shipping.php
+++ b/app/code/Magento/Tax/Block/Checkout/Shipping.php
@@ -15,7 +15,7 @@ class Shipping extends \Magento\Checkout\Block\Total\DefaultTotal
      *
      * @var string
      */
-    protected $_template = 'checkout/shipping.phtml';
+    protected $_template = 'Magento_Tax::checkout/shipping.phtml';
 
     /**
      * @var \Magento\Tax\Model\Config

--- a/app/code/Magento/Tax/Block/Checkout/Subtotal.php
+++ b/app/code/Magento/Tax/Block/Checkout/Subtotal.php
@@ -15,7 +15,7 @@ class Subtotal extends \Magento\Checkout\Block\Total\DefaultTotal
      *
      * @var string
      */
-    protected $_template = 'checkout/subtotal.phtml';
+    protected $_template = 'Magento_Tax::checkout/subtotal.phtml';
 
     /**
      * @var \Magento\Tax\Model\Config

--- a/app/code/Magento/Tax/Block/Checkout/Tax.php
+++ b/app/code/Magento/Tax/Block/Checkout/Tax.php
@@ -14,5 +14,5 @@ class Tax extends \Magento\Checkout\Block\Total\DefaultTotal
     /**
      * @var string
      */
-    protected $_template = 'checkout/tax.phtml';
+    protected $_template = 'Magento_Tax::checkout/tax.phtml';
 }

--- a/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExport.php
+++ b/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExport.php
@@ -10,7 +10,7 @@ class ImportExport extends \Magento\Backend\Block\Widget
     /**
      * @var string
      */
-    protected $_template = 'importExport.phtml';
+    protected $_template = 'Magento_TaxImportExport::importExport.phtml';
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context

--- a/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExportHeader.php
+++ b/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/ImportExportHeader.php
@@ -16,5 +16,5 @@ class ImportExportHeader extends \Magento\Backend\Block\Widget
      *
      * @var string
      */
-    protected $_template = 'importExportHeader.phtml';
+    protected $_template = 'Magento_TaxImportExport::importExportHeader.phtml';
 }

--- a/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/Wysiwyg/Files/Content/Uploader.php
@@ -17,7 +17,7 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
      *
      * @var string
      */
-    protected $_template = 'browser/content/uploader.phtml';
+    protected $_template = 'Magento_Theme::browser/content/uploader.phtml';
 
     /**
      * @var \Magento\Theme\Helper\Storage

--- a/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
+++ b/app/code/Magento/Theme/Block/Html/Breadcrumbs.php
@@ -15,7 +15,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'html/breadcrumbs.phtml';
+    protected $_template = 'Magento_Theme::html/breadcrumbs.phtml';
 
     /**
      * List of available breadcrumb properties

--- a/app/code/Magento/Theme/Block/Html/Header.php
+++ b/app/code/Magento/Theme/Block/Html/Header.php
@@ -16,7 +16,7 @@ class Header extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'html/header.phtml';
+    protected $_template = 'Magento_Theme::html/header.phtml';
 
     /**
      * Retrieve welcome text

--- a/app/code/Magento/Theme/Block/Html/Header/Logo.php
+++ b/app/code/Magento/Theme/Block/Html/Header/Logo.php
@@ -16,7 +16,7 @@ class Logo extends \Magento\Framework\View\Element\Template
      *
      * @var string
      */
-    protected $_template = 'html/header/logo.phtml';
+    protected $_template = 'Magento_Theme::html/header/logo.phtml';
 
     /**
      * @var \Magento\MediaStorage\Helper\File\Storage\Database

--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -67,6 +67,7 @@
             border-bottom-left-radius: 0;
             border-top-left-radius: 0;
             margin-left: -1px;
+            white-space: nowrap;
         }
     }
 }

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -555,7 +555,7 @@ class TypeProcessor
         if ($type == 'array') {
             // try to determine class, if it's array of objects
             $docBlock = $param->getDeclaringFunction()->getDocBlock();
-            $pattern = "/\@param\s+([\w\\\_]+\[\])\s+\\\${$param->getName()}\n/";
+            $pattern = "/\@param\s+([\w\\\_]+\[\])\s+\\\${$param->getName()}[\n\r]/";
             $matches = [];
             if (preg_match($pattern, $docBlock->getContents(), $matches)) {
                 return $matches[1];

--- a/lib/web/css/source/lib/_buttons.less
+++ b/lib/web/css/source/lib/_buttons.less
@@ -266,8 +266,7 @@
     &.disabled,
     &[disabled],
     fieldset[disabled] & {
-        cursor: not-allowed;
-        pointer-events: none; // Disabling of clicks
+        pointer-events: none; // Disabling of all pointer events
         .lib-css(opacity, @button__disabled__opacity);
     }
 }

--- a/lib/web/css/source/lib/_rating.less
+++ b/lib/web/css/source/lib/_rating.less
@@ -38,7 +38,7 @@
     input[type="radio"] {
         .lib-visually-hidden();
 
-        &:focus,
+        &:hover,
         &:checked {
             + label {
                 &:before {

--- a/lib/web/css/source/lib/_utilities.less
+++ b/lib/web/css/source/lib/_utilities.less
@@ -260,9 +260,8 @@
     @_line-height: normal
 ) {
     .lib-font-size(@_font-size);
-    font-size: @_font-size;
+    .lib-line-height(@_line-height);
     letter-spacing: normal;
-    line-height: @_line-height;
 }
 
 //


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13029
<!--- Provide a general summary of the Pull Request in the Title above -->
When Set the newsletter subscribe button's title with at least two Chinese characters (either by changing it with your browser's Developer Tool or by switching the CMS language to Chinese), for instance "订阅". getting Wrap on Newsletter box.
### Description
<!--- Provide a description of the changes proposed in the pull request -->


### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#12320, if relevant  -->
1. magento/magento2#12320: Newsletter subscribe button title wrapped

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add  two characters of the Chinese word "订阅" in translate for Newsletter "Subscribe"
Actual Result:
![screenshot from 2018-01-07 10-56-07](https://user-images.githubusercontent.com/18435810/34647027-df5c115c-f39c-11e7-952a-42c70b594aad.png)


Expected Result:
![screenshot from 2018-01-07 10-57-42](https://user-images.githubusercontent.com/18435810/34647019-cc5d99c2-f39c-11e7-9e37-6a5ff125347f.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
