### PR TITLE
[Forwardport] [BUGFIX] Added row_id to the flat action indexer so the value isn't s…

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Indexer.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Indexer.php
@@ -175,6 +175,7 @@ class Indexer
 
         if (!empty($updateData)) {
             $updateData += ['entity_id' => $productId];
+            $updateData += ['row_id' => $productId];
             $updateFields = [];
             foreach ($updateData as $key => $value) {
                 $updateFields[$key] = $key;

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -294,7 +294,8 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
         ValidatorInterface::ERROR_MEDIA_PATH_NOT_ACCESSIBLE => 'Imported resource (image) does not exist in the local media storage',
         ValidatorInterface::ERROR_MEDIA_URL_NOT_ACCESSIBLE => 'Imported resource (image) could not be downloaded from external resource due to timeout or access permissions',
         ValidatorInterface::ERROR_INVALID_WEIGHT => 'Product weight is invalid',
-        ValidatorInterface::ERROR_DUPLICATE_URL_KEY => 'Url key: \'%s\' was already generated for an item with the SKU: \'%s\'. You need to specify the unique URL key manually'
+        ValidatorInterface::ERROR_DUPLICATE_URL_KEY => 'Url key: \'%s\' was already generated for an item with the SKU: \'%s\'. You need to specify the unique URL key manually',
+        ValidatorInterface::ERROR_DUPLICATE_MULTISELECT_VALUES => "Value for multiselect attribute %s contains duplicated values",
     ];
     //@codingStandardsIgnoreEnd
 

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/RowValidatorInterface.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/RowValidatorInterface.php
@@ -85,6 +85,8 @@ interface RowValidatorInterface extends \Magento\Framework\Validator\ValidatorIn
 
     const ERROR_DUPLICATE_URL_KEY = 'duplicatedUrlKey';
 
+    const ERROR_DUPLICATE_MULTISELECT_VALUES = 'duplicatedMultiselectValues';
+
     /**
      * Value that means all entities (e.g. websites, groups etc.)
      */

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Validator.php
@@ -219,6 +219,12 @@ class Validator extends AbstractValidator implements RowValidatorInterface
                         break;
                     }
                 }
+
+                $uniqueValues = array_unique($values);
+                if (count($uniqueValues) != count($values)) {
+                    $valid = false;
+                    $this->_addMessages([RowValidatorInterface::ERROR_DUPLICATE_MULTISELECT_VALUES]);
+                }
                 break;
             case 'datetime':
                 $val = trim($rowData[$attrCode]);

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/ValidatorTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/ValidatorTest.php
@@ -169,6 +169,26 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
             ],
             [
                 Import::BEHAVIOR_APPEND,
+                ['is_required' => true, 'type' => 'multiselect',
+                    'options' => ['option 1' => 0, 'option 2' => 1, 'option 3']],
+                ['product_type' => 'any', 'attribute_code' => 'Option 1|Option 2|Option 1'],
+                false
+            ],
+            [
+                Import::BEHAVIOR_APPEND,
+                ['is_required' => true, 'type' => 'multiselect',
+                    'options' => ['option 1' => 0, 'option 2' => 1, 'option 3']],
+                ['product_type' => 'any', 'attribute_code' => 'Option 3|Option 3|Option 3|Option 1'],
+                false
+            ],
+            [
+                Import::BEHAVIOR_APPEND,
+                ['is_required' => true, 'type' => 'multiselect', 'options' => ['option 1' => 0]],
+                ['product_type' => 'any', 'attribute_code' => 'Option 1|Option 1|Option 1|Option 1'],
+                false
+            ],
+            [
+                Import::BEHAVIOR_APPEND,
                 ['is_required' => true, 'type' => 'datetime'],
                 ['product_type' => 'any', 'attribute_code' => '1/1/15 12am'],
                 true

--- a/app/code/Magento/CatalogRule/Model/Rule/Job.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Job.php
@@ -34,18 +34,18 @@ class Job extends \Magento\Framework\DataObject
      */
     protected $ruleProcessor;
 
-	/**
-	 * Basic object initialization
-	 *
-	 * @param RuleProductProcessor $ruleProcessor
-	 * @param array $data
-	 */
+    /**
+     * Basic object initialization
+     *
+     * @param RuleProductProcessor $ruleProcessor
+     * @param array $data
+     */
     public function __construct(
     	RuleProductProcessor $ruleProcessor,
-		array $data = []
+    	array $data = []
     ) {
-	    $this->ruleProcessor = $ruleProcessor;
-	    parent::__construct($data);
+        $this->ruleProcessor = $ruleProcessor;
+        parent::__construct($data);
     }
 
     /**

--- a/app/code/Magento/CatalogRule/Model/Rule/Job.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Job.php
@@ -8,6 +8,10 @@
  * See COPYING.txt for license details.
  */
 
+namespace Magento\CatalogRule\Model\Rule;
+
+use Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor;
+
 /**
  * Catalog Rule job model
  *
@@ -18,13 +22,8 @@
  * @method bool hasSuccess()
  * @method bool hasError()
  *
- * @author    Magento Core Team <core@magentocommerce.com>
- */
-namespace Magento\CatalogRule\Model\Rule;
-
-use Magento\CatalogRule\Model\Indexer\Rule\RuleProductProcessor;
-
-/**
+ * @author Magento Core Team <core@magentocommerce.com>
+ *
  * @api
  * @since 100.0.2
  */
@@ -35,14 +34,18 @@ class Job extends \Magento\Framework\DataObject
      */
     protected $ruleProcessor;
 
-    /**
-     * Basic object initialization
-     *
-     * @param RuleProductProcessor $ruleProcessor
-     */
-    public function __construct(RuleProductProcessor $ruleProcessor)
-    {
-        $this->ruleProcessor = $ruleProcessor;
+	/**
+	 * Basic object initialization
+	 *
+	 * @param RuleProductProcessor $ruleProcessor
+	 * @param array $data
+	 */
+    public function __construct(
+    	RuleProductProcessor $ruleProcessor,
+		array $data = []
+    ) {
+	    $this->ruleProcessor = $ruleProcessor;
+	    parent::__construct($data);
     }
 
     /**

--- a/app/code/Magento/CatalogRule/Model/Rule/Job.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Job.php
@@ -41,8 +41,8 @@ class Job extends \Magento\Framework\DataObject
      * @param array $data
      */
     public function __construct(
-    	RuleProductProcessor $ruleProcessor,
-    	array $data = []
+        RuleProductProcessor $ruleProcessor,
+        array $data = []
     ) {
         $this->ruleProcessor = $ruleProcessor;
         parent::__construct($data);

--- a/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
@@ -14,7 +14,7 @@
         <div class="field email required">
             <label for="email_address" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}">
+                <input type="email" name="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}" data-mage-init='{"mage/trim-input":{}}'>
             </div>
         </div>
     </fieldset>

--- a/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
@@ -14,7 +14,7 @@
         <div class="field email required">
             <label for="email_address" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}" data-mage-init='{"mage/trim-input":{}}'>
+                <input type="email" name="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}">
             </div>
         </div>
     </fieldset>

--- a/app/code/Magento/GroupedProduct/Model/Product/Initialization/Helper/ProductLinks/Plugin/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Initialization/Helper/ProductLinks/Plugin/Grouped.php
@@ -8,6 +8,7 @@ namespace Magento\GroupedProduct\Model\Product\Initialization\Helper\ProductLink
 use Magento\Catalog\Api\Data\ProductLinkExtensionFactory;
 use Magento\Catalog\Api\Data\ProductLinkInterfaceFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\GroupedProduct\Model\Product\Type\Grouped as TypeGrouped;
 
 /**
@@ -60,6 +61,9 @@ class Grouped
      * @param array $links
      *
      * @return \Magento\Catalog\Model\Product
+     *
+     * @throws NoSuchEntityException
+     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -70,7 +74,7 @@ class Grouped
         array $links
     ) {
         if ($product->getTypeId() === TypeGrouped::TYPE_CODE && !$product->getGroupedReadonly()) {
-            $links = (isset($links[self::TYPE_NAME])) ? $links[self::TYPE_NAME] : $product->getGroupedLinkData();
+            $links = $links[self::TYPE_NAME] ?? $product->getGroupedLinkData();
             if (!is_array($links)) {
                 $links = [];
             }

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassDelete.php
@@ -6,8 +6,32 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml\Subscriber;
 
-class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
+use Magento\Newsletter\Controller\Adminhtml\Subscriber;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Framework\App\ObjectManager;
+
+class MassDelete extends Subscriber
 {
+    /**
+     * @var SubscriberFactory
+     */
+    private $subscriberFactory;
+    
+    /**
+     * @param Context $context
+     * @param FileFactory $fileFactory
+     */
+    public function __construct(
+        Context $context,
+        FileFactory $fileFactory,
+        SubscriberFactory $subscriberFactory = null
+    ) {
+        $this->subscriberFactory = $subscriberFactory ?: ObjectManager::getInstance()->get(SubscriberFactory::class);
+        parent::__construct($context, $fileFactory);
+    }
+    
     /**
      * Delete one or more subscribers action
      *
@@ -21,9 +45,7 @@ class MassDelete extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
-                    $subscriber = $this->_objectManager->create(
-                        \Magento\Newsletter\Model\Subscriber::class
-                    )->load(
+                    $subscriber = $this->subscriberFactory->create()->load(
                         $subscriberId
                     );
                     $subscriber->delete();

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -22,6 +22,7 @@ class MassUnsubscribe extends Subscriber
     /**
      * @param Context $context
      * @param FileFactory $fileFactory
+     * @param SubscriberFactory $subscriberFactory
      */
     public function __construct(
         Context $context,

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Subscriber/MassUnsubscribe.php
@@ -6,8 +6,32 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml\Subscriber;
 
-class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscriber
+use Magento\Newsletter\Controller\Adminhtml\Subscriber;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Framework\App\ObjectManager;
+
+class MassUnsubscribe extends Subscriber
 {
+    /**
+     * @var SubscriberFactory
+     */
+    private $subscriberFactory;
+    
+    /**
+     * @param Context $context
+     * @param FileFactory $fileFactory
+     */
+    public function __construct(
+        Context $context,
+        FileFactory $fileFactory,
+        SubscriberFactory $subscriberFactory = null
+    ) {
+        $this->subscriberFactory = $subscriberFactory ?: ObjectManager::getInstance()->get(SubscriberFactory::class);
+        parent::__construct($context, $fileFactory);
+    }
+    
     /**
      * Unsubscribe one or more subscribers action
      *
@@ -21,9 +45,7 @@ class MassUnsubscribe extends \Magento\Newsletter\Controller\Adminhtml\Subscribe
         } else {
             try {
                 foreach ($subscribersIds as $subscriberId) {
-                    $subscriber = $this->_objectManager->create(
-                        \Magento\Newsletter\Model\Subscriber::class
-                    )->load(
+                    $subscriber = $this->subscriberFactory->create()->load(
                         $subscriberId
                     );
                     $subscriber->unsubscribe();

--- a/app/code/Magento/ProductVideo/i18n/en_US.csv
+++ b/app/code/Magento/ProductVideo/i18n/en_US.csv
@@ -40,4 +40,3 @@ Delete,Delete
 "Autostart base video","Autostart base video"
 "Show related video","Show related video"
 "Auto restart video","Auto restart video"
-"Images And Videos","Images And Videos"

--- a/app/code/Magento/Ui/view/base/web/templates/form/components/collection.html
+++ b/app/code/Magento/Ui/view/base/web/templates/form/components/collection.html
@@ -30,7 +30,7 @@
                 <legend class="admin__legend">
                     <span text="$parent.label"/>
                 </legend><br />
-                
+
                 <each args="getRegion('body')" render=""/>
             </fieldset>
         </div>

--- a/app/code/Magento/Ui/view/base/web/templates/form/element/checkbox-set.html
+++ b/app/code/Magento/Ui/view/base/web/templates/form/element/checkbox-set.html
@@ -16,14 +16,14 @@
     <div class="admin__field-control"
          css="'_with-tooltip': $data.tooltip">
         <div class="admin__field admin__field-option" outereach="options">
-            <input 
+            <input
                 ko-checked="$parent.value"
                 ko-disabled="$parent.disabled"
                 css="
                     'admin__control-radio': !$parent.multiple,
                     'admin__control-checkbox': $parent.multiple"
                 attr="
-                    id: ++ko.uid, 
+                    id: ++ko.uid,
                     value: value,
                     type: $parent.multiple ? 'checkbox' : 'radio'"/>
 

--- a/app/code/Magento/Ui/view/base/web/templates/form/field.html
+++ b/app/code/Magento/Ui/view/base/web/templates/form/field.html
@@ -35,7 +35,7 @@
         <div class="admin__field-note" if="$data.notice" attr="id: noticeId">
             <span translate="notice"/>
         </div>
-        
+
         <div class="admin__additional-info" if="$data.additionalInfo" html="$data.additionalInfo"></div>
 
         <render args="$data.service.template" if="$data.hasService()"/>

--- a/app/code/Magento/Ui/view/base/web/templates/grid/editing/bulk.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/editing/bulk.html
@@ -13,7 +13,7 @@
                 </button>
             </with>
         </if>
-        
+
         <if args="$data.isEditor">
             <label class="admin__field-label admin__field-label-vertical" attr="for: uid" translate="'All in Column'"/>
             <render/>

--- a/app/code/Magento/Ui/view/base/web/templates/grid/editing/row.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/editing/row.html
@@ -11,8 +11,8 @@
             <span class="data-grid-row-changed" css="_changed: $parent.hasChanges">
                 <span class="data-grid-row-changed-tooltip" translate="'Record contains unsaved changes.'"/>
             </span>
-        </td>        
-        
+        </td>
+
         <!-- ko ifnot: $parent.isActionsColumn($data) -->
             <td if="$col.isEditor" template="$parent.fieldTmpl"/>
             <td ifnot="$col.isEditor" css="$col.getFieldClass()" template="$col.getBody()"/>

--- a/app/code/Magento/Ui/view/base/web/templates/grid/sticky/sticky.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/sticky/sticky.html
@@ -7,7 +7,7 @@
 <div style="display: none;" css="stickyClass" afterRender="setStickyNode">
     <span class="data-grid-cap-left" afterRender="setLeftCap"/>
     <span class="data-grid-cap-right" afterRender="setRightCap"/>
-    
+
     <div afterRender="setStickyToolbarNode">
         <div class="admin__data-grid-header">
             <div class="admin__data-grid-header-row">

--- a/app/code/Magento/Ui/view/base/web/templates/group/group.html
+++ b/app/code/Magento/Ui/view/base/web/templates/group/group.html
@@ -19,7 +19,7 @@
                 <render args="elementTmpl" if="element.input_type == 'checkbox' || element.input_type == 'radio'"/>
             </if>
         </each>
-        
+
         <each args="getRegion('insideGroup')" render=""/>
 
         <each args="elems" if="validateWholeGroup">

--- a/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
@@ -93,6 +93,21 @@
                 }
             }
         }
+        .fieldset.create.account {
+            .lib-form-hasrequired(bottom);
+            &:after {
+                margin-top: 35px;
+            }
+        }
+    }
+
+    .form.password.forget {
+        .fieldset {
+            .lib-form-hasrequired(bottom);
+            &:after {
+                margin-top: 35px;
+            }
+        }
     }
 
     //  Full name fieldset

--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,8 @@
         },
         "psr-0": {
             "": [
-                "app/code/"
+                "app/code/",
+                "generated/code/"
             ]
         },
         "files": [

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -61,12 +61,13 @@ class RowTest extends \Magento\TestFramework\Indexer\TestCase
             $this->_processor->getIndexer()->isScheduled(),
             'Indexer is in scheduled mode when turned to update on save mode'
         );
-        $this->_processor->reindexAll();
 
         $this->_product->load(1);
         $this->_product->setName('Updated Product');
         $this->_product->save();
 
+        $this->_processor->reindexAll();
+        
         $category = $categoryFactory->create()->load(9);
         $layer = $listProduct->getLayer();
         $layer->setCurrentCategory($category);

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -108,13 +108,6 @@ class Bootstrap
     private $factory;
 
     /**
-     * Logger
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * Static method so that client code does not have to create Object Manager Factory every time Bootstrap is called
      *
      * @param string $rootDir
@@ -214,7 +207,6 @@ class Bootstrap
         $this->rootDir = $rootDir;
         $this->server = $initParams;
         $this->objectManager = $this->factory->create($this->server);
-        $this->logger = $this->objectManager->create(LoggerInterface::class);
     }
 
     /**
@@ -267,7 +259,7 @@ class Bootstrap
                 \Magento\Framework\Profiler::stop('magento');
             } catch (\Exception $e) {
                 \Magento\Framework\Profiler::stop('magento');
-                $this->logger->error($e->getMessage());
+                $this->objectManager->get(LoggerInterface::class)->error($e);
                 if (!$application->catchException($this, $e)) {
                     throw $e;
                 }

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -108,6 +108,13 @@ class Bootstrap
     private $factory;
 
     /**
+     * Logger
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Static method so that client code does not have to create Object Manager Factory every time Bootstrap is called
      *
      * @param string $rootDir
@@ -207,6 +214,7 @@ class Bootstrap
         $this->rootDir = $rootDir;
         $this->server = $initParams;
         $this->objectManager = $this->factory->create($this->server);
+        $this->logger = $this->objectManager->create(LoggerInterface::class);
     }
 
     /**
@@ -259,6 +267,7 @@ class Bootstrap
                 \Magento\Framework\Profiler::stop('magento');
             } catch (\Exception $e) {
                 \Magento\Framework\Profiler::stop('magento');
+                $this->logger->error($e->getMessage());
                 if (!$application->catchException($this, $e)) {
                     throw $e;
                 }

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -12,6 +12,7 @@ use Magento\Framework\Autoload\AutoloaderRegistry;
 use Magento\Framework\Autoload\Populator;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Filesystem\DriverPool;
+use Psr\Log\LoggerInterface;
 
 /**
  * A bootstrap of Magento application
@@ -423,7 +424,7 @@ class Bootstrap
                 if (!$this->objectManager) {
                     throw new \DomainException();
                 }
-                $this->objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
+                $this->objectManager->get(LoggerInterface::class)->critical($e);
             } catch (\Exception $e) {
                 $message .= "Could not write error message to log. Please use developer mode to see the message.\n";
             }

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -259,7 +259,7 @@ class Bootstrap
                 \Magento\Framework\Profiler::stop('magento');
             } catch (\Exception $e) {
                 \Magento\Framework\Profiler::stop('magento');
-                $this->objectManager->get(LoggerInterface::class)->error($e);
+                $this->objectManager->get(LoggerInterface::class)->error($e->getMessage());
                 if (!$application->catchException($this, $e)) {
                     throw $e;
                 }

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -3,7 +3,6 @@
 #    # use tcp connection
 #    # server  127.0.0.1:9000;
 #    # or socket
-#    server   unix:/var/run/php5-fpm.sock;
 #    server   unix:/var/run/php/php7.0-fpm.sock;
 # }
 # server {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15010
**reopen https://github.com/magento/magento2/pull/13446**

…et to 0 for new products when using index on save

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
If you use the `\Magento\Framework\Api\SearchCriteriaBuilder` and the flat product row_id is set to 0. The product isn't shown in the getList of the ProductRepository

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
**Issue was in the Commerce (EE) version but can be solved in the Open Source Codebase**
1. Enable Product Flat Catalog `Stores > Settings > Configuration > Catalog > Catalog > Storefront > Use Flat Catalog Product`
2. Run the index manually through the command line `php bin/magento indexer:reindex catalog_product_flat`
3. Set the Indexes to On Save `System > Tools > Index Management > Select all and select the action Update on Save`
4. Create a New Product with SKU `test`
5. Take a look in the database in the catalog_product_flat_1 tabel and search for the product with SKU `test`
6. The row_id will be set to **0**
7. Apply Changes
8. Save the Product
9. Take a look at the database in the catalog_product_flat_1 tabel and search for the product with SKU `test`
10. The row_id should now be equal to the entity_id

Besides looking in the database you could create a simpel collection by using the SearchCritieria and the ProductRepository

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
